### PR TITLE
FIX: sub field is not returned with dynamic scopes

### DIFF
--- a/lib/helpers/claims.js
+++ b/lib/helpers/claims.js
@@ -6,7 +6,7 @@ const instance = require('./weak_cache');
 
 module.exports = function getClaims(provider) {
   const {
-    claims: claimConfig, claimsSupported, dynamicScopes, pairwiseIdentifier,
+    claims: claimConfig, claimsSupported, scopes, dynamicScopes, pairwiseIdentifier,
   } = instance(provider).configuration();
 
   return class Claims {
@@ -24,10 +24,12 @@ module.exports = function getClaims(provider) {
     scope(value = '') {
       assert(!Object.keys(this.filter).length, 'scope cannot be assigned after mask has been set');
       value.split(' ').forEach((scope) => {
-        for (const dynamic of dynamicScopes) { // eslint-disable-line no-restricted-syntax
-          if (dynamic.test(scope)) {
-            scope = dynamic; // eslint-disable-line no-param-reassign
-            break;
+        if (!scopes.includes(scope)) {
+          for (const dynamic of dynamicScopes) { // eslint-disable-line no-restricted-syntax
+            if (dynamic.test(scope)) {
+              scope = dynamic; // eslint-disable-line no-param-reassign
+              break;
+            }
           }
         }
 


### PR DESCRIPTION
When using dynimic scopes as outlined here #466 id_token does not contains sub field. This is already fixed in 6.X version and this is for 5.X version